### PR TITLE
Add concourse pipeline to update cnx rex redirects

### DIFF
--- a/rex-redirects/README.md
+++ b/rex-redirects/README.md
@@ -1,0 +1,44 @@
+Concourse pipeline for updating CNX's REX redirects
+===================================================
+
+This is a concourse pipeline that is triggered by new versions of
+https://staging.openstax.org/rex/environment.json (configurable), regenerates
+the `rex-uris.map` files based on what books are on the rex release, pushes a
+branch in cnx-deploy called `update-rex-redirects-staging` (configurable) and
+creates a pull request for developers to review.
+
+There are a number of variables that this pipeline uses.  You will need to set
+these up.
+
+1. Copy `vars.yml.example` to `vars.yml`:
+
+   ```
+   cp vars.yml.example vars.yml
+   ```
+
+2. Paste your existing private github ssh key in `git-private-key`.
+
+   1. Alternatively, you can generate a new one using `ssh-keygen`.  See
+      github's guides
+      https://help.github.com/en/articles/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent#generating-a-new-ssh-key
+      and
+      https://help.github.com/en/articles/adding-a-new-ssh-key-to-your-github-account
+
+3. Fill in `git-author-name` and `git-author-email`.  These are used as the
+   author of the commits for updating `rex-uris.map` files.
+
+4. Decide which `rex-domain` this pipeline is watching, for example,
+   `staging.openstax.org` for non prod environments.
+
+5. Create a github token for the pipeline to create a pull request.
+
+   1. Log in at github.com
+   2. Go to github.com and select `settings` from the top right menu
+   3. Click on `developer settings`
+   4. Click on `personal access tokens`
+   5. Select `public_repo` and save
+   6. Copy and paste the token into the `github-token` field
+
+6. Put in the github usernames of all the users that should review the pull
+   request, separated by commas in `reviewers`.
+

--- a/rex-redirects/create_pr.sh
+++ b/rex-redirects/create_pr.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -xe
+
+# no branch is checked out at this point
+git checkout "$CNX_DEPLOY_BRANCH"
+
+# download hub (commandline program to do github stuff)
+wget "https://github.com/github/hub/releases/download/v$HUB_VERSION/hub-linux-amd64-$HUB_VERSION.tgz"
+tar xf "hub-linux-amd64-$HUB_VERSION.tgz" "hub-linux-amd64-$HUB_VERSION/bin/hub"
+
+# check whether PR already exists
+if [ -z "$("hub-linux-amd64-$HUB_VERSION/bin/hub" pr list -h "$CNX_DEPLOY_BRANCH")" ]
+then
+  "hub-linux-amd64-$HUB_VERSION/bin/hub" pull-request -f --no-edit -r "$REVIEWERS"
+fi

--- a/rex-redirects/pipeline.yml
+++ b/rex-redirects/pipeline.yml
@@ -1,0 +1,101 @@
+resource_types:
+- name: curl
+  type: docker-image
+  source:
+    repository: pivotalservices/concourse-curl-resource
+    tag: latest
+
+resources:
+- name: rex-environment-json
+  type: curl
+  source:
+    url: https://((openstax-host))/rex/environment.json
+    filename: environment.json
+
+- name: cnx-deploy
+  type: git
+  source:
+    uri: git@github.com:openstax/cnx-deploy.git
+    private_key: ((git-private-key))
+
+- name: cnx-deploy-branch
+  type: git
+  source:
+    uri: git@github.com:openstax/cnx-deploy.git
+    branch: ((cnx-deploy-branch))
+    private_key: ((git-private-key))
+    git_config:
+    - name: user.email
+      value: ((git-author-email))
+    - name: user.name
+      value: ((git-author-name))
+
+- name: concourse-pipelines
+  type: git
+  source:
+    uri: https://github.com/openstax/concourse-pipelines.git
+
+jobs:
+- name: job-update-rex-redirects
+  plan:
+  - get: rex-environment-json
+    trigger: true
+  - get: cnx-deploy
+  - get: concourse-pipelines
+
+  - task: update-uri-maps
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: python
+          tag: 3.7-buster
+      inputs:
+      - name: cnx-deploy
+      - name: concourse-pipelines
+      outputs:
+      - name: cnx-deploy-updated
+      run:
+        path: /bin/bash
+        args:
+        - -c
+        - |
+          cp -r cnx-deploy cnx-deploy-updated && \
+          cd cnx-deploy-updated/cnx-deploy && \
+          ../../concourse-pipelines/rex-redirects/update_uri_map.sh
+    params:
+      OPENSTAX_HOST: ((openstax-host))
+      ARCHIVE_HOST: ((archive-host))
+      CNX_DEPLOY_BRANCH: ((cnx-deploy-branch))
+      GIT_AUTHOR_EMAIL: ((git-author-email))
+      GIT_AUTHOR_NAME: ((git-author-name))
+
+  - put: cnx-deploy-branch
+    params:
+      repository: cnx-deploy-updated/cnx-deploy
+      force: true
+
+  - task: create-pr
+    config:
+      platform: linux
+      image_resource:
+        type: docker-image
+        source:
+          repository: python
+          tag: 3.7-buster
+      inputs:
+      - name: cnx-deploy-updated
+      - name: concourse-pipelines
+      run:
+        path: /bin/bash
+        args:
+        - -c
+        - |
+          cd cnx-deploy-updated/cnx-deploy && \
+          ../../concourse-pipelines/rex-redirects/create_pr.sh
+    params:
+      HUB_VERSION: 2.12.3
+      GITHUB_TOKEN: ((github-token))
+      CNX_DEPLOY_BRANCH: ((cnx-deploy-branch))
+      REVIEWERS: ((reviewers))

--- a/rex-redirects/pipeline.yml
+++ b/rex-redirects/pipeline.yml
@@ -33,7 +33,9 @@ resources:
 - name: concourse-pipelines
   type: git
   source:
-    uri: https://github.com/openstax/concourse-pipelines.git
+    #uri: https://github.com/openstax/concourse-pipelines.git
+    uri: https://github.com/karenc/concourse-pipelines.git
+    branch: rex-redirects
 
 jobs:
 - name: job-update-rex-redirects

--- a/rex-redirects/update_uri_map.sh
+++ b/rex-redirects/update_uri_map.sh
@@ -1,0 +1,30 @@
+#!/bin/bash
+
+set -xe
+
+git checkout -b "$CNX_DEPLOY_BRANCH"
+
+# TODO install pypi version (not currently available)
+pip install git+https://github.com/openstax/cnx-rex-redirects.git
+
+git config --global user.email "$GIT_AUTHOR_EMAIL"
+git config --global user.name "$GIT_AUTHOR_NAME"
+
+# find all the environments with rex_domain $OPENSTAX_HOST
+git grep -l "rex_domain: *$OPENSTAX_HOST" environments/*/group_vars/ | cut -d/ -f2 | while read environment
+do
+  map_file="environments/$environment/files/etc/nginx/uri-maps/rex-uris.map"
+  # get the original file in case it's symlinked
+  echo "$(python -c "import os.path; print(os.path.relpath(os.path.realpath('$map_file')))")"
+  # get all the unique map files
+done | sort | uniq | while read output_file
+do
+  environment="$(echo "$output_file" | cut -d/ -f2)"
+  mkdir -p "$(dirname "$output_file")"
+  rex_redirects -o "$output_file" --archive-host "$ARCHIVE_HOST" --openstax-host "$OPENSTAX_HOST" update-rex-redirects
+
+  echo -e "Update rex redirects for $environment\n" >commit-message.txt
+  git add "$output_file"
+  git diff --cached | sed -n 's/^\([-+]\)[^ ]* *\/books\/\([^/]*\).*$/\1\2/ p' | uniq >>commit-message.txt
+  git commit -a -F commit-message.txt || echo "No changes to $environment rex-uris.map"
+done

--- a/rex-redirects/vars.yml.example
+++ b/rex-redirects/vars.yml.example
@@ -1,0 +1,42 @@
+git-private-key: |
+    -----BEGIN RSA PRIVATE KEY-----
+    MIIEogIBAAKCAQEAv2NwpbUHcaUByu4+PrcfIhqeDIsbub6qnJNY9ozKt9iUrkBH
+    Qt7dVQ9zw1qPFznv2Z8Zt1CvwHH2vv7A8+Dg2ObT9Is23SIckqUSYFCA4Q9KV6AW
+    eo7fi1ai8lpFtS+01AZzoi/nTAV15WI78QZaWGf8Esy2EA9vTdNIXENs80+91GjB
+    yMOnSOfGEk4uTLX26GWWHsWwF9Uyl64ATPv1YLh2VkN2jLil2Vug9MJKdlNIoIyi
+    h1/n3KPUKTtit0u2RZ7I89q4QACq0bdlQfQ59lA9OdnTlCMu4F1FRGsyeiMmSYSq
+    MOSjETzjq+DOMwv1Q4rKBgntXtC5BMP/E9qOrQIDAQABAoIBAAYKCT/xWm7Hmirh
+    Ia2w8ZaN6HbU3OcbkR6nt6LwBmWOvAJTnOwLREiu2CRN8z30YhEn6BPUw/b6oaKd
+    P1FywyWVAxMwYWbQ8L3f35iScb6oUNw6/PqZD4zCCxpCpvh0rOwT2ApCILZRZcr7
+    MpEEdk1b2qRtOUGAey6lgB8JMaLrz0K0Kun1wREnNDYufF2z0PZco4HbwwlacXOq
+    Hcrtb81+wRau9I46FPaIROcja2cB/HTGnSWl/shBt/QTqSLH9vDwh3mz/1YO780g
+    5Ue+8RearazC/R76rAV2jBy2zG68M47kVX5xL24bBJI8BuGERbQCwLW+VToR7ptU
+    uUjTKrECgYEA5kFh/yOasuS+RGGI4DlMr0Z0zFQ3bhX2/958/6JPKvMq4otT0tL2
+    eQs1of2Facrmyi7SOBg0PpYhZe02VEXNAPjZu/GT0/M30N7xOoCgJJRbS8JvuB6Y
+    C5ywIeiCFgQvHFhcn4vG+3VY126LthXGzQSJ8ZirTIXzop81b230nZsCgYEA1MmQ
+    tgCuxP2hKt1/K+Lc0YOJkAsEfci9qkrSvbC2WyXuzgtNUeCMzCwTvqrxTFCjB0NM
+    QFAU1JI1KLBuYFaerkFyTpbkObV6YpsLMRzoCLA4n1amx4hiqHJmInXLQmYHj7+n
+    QEY1MNt2x8B6F+xai702uqfq4yY2oOLqleS6bVcCgYB/tt5jRV1mQshiZ3MjY8Ts
+    J3lbaI8CSb6iN8c/h8i/uvcbh0psUsWRaC1Md7GLd5bBqGzD3nEEEgPeZE/ROJI4
+    Ks+ilqF3W52nBjHpUDUDdSKah/OtvZJ6RmPPuwaErbdv0nc1q7MoAPPRMqjdy4Bk
+    cVMOJa9GF7qGhiZ+cw/OZwKBgHFivvPcxUQ/CmR3Bs7x4kzaVLEmzcvg7gASQt3F
+    jkZfnjK5HwhkKWKakiLloBLUXSr/l2AlzBPBnQYDja1UOtYMFcb+7Lo7k+17RKl1
+    B8epb2Kon9JvQHMWEoqGTjshdyIINC0xvCI+r7qdO/IHhfA0cTdhRu6nbDCq+enJ
+    qfWdAoGAHA2jQ/BXwfWv+1iklRLJyOmzbCD2qSLAU8I1b2xOMt8Z1ufp8+qN4zGj
+    6bByRI6KOYj6BLrJNn/Dn+y6VpI39QXGnHnAGO4WKhjbOOw0DDW1deFIfXTQ1gNF
+    vFCW2AStBGlUlrb86dLHGj4+r9SmlptjC5a39O6q5s31GOZEKn8=
+    -----END RSA PRIVATE KEY-----
+git-author-name: First Last
+git-author-email: first@example.org
+cnx-deploy-branch: update-rex-redirects-staging
+
+openstax-host: staging.openstax.org
+archive-host: archive-staging.cnx.org
+
+# github.com -> top right dropdown menu -> settings -> developer settings -> personal access tokens
+#   scope: public_repo
+github-token: ddce5dc0db5146eea35f88d63cb104f0
+
+# reviewers cannot include PR author
+# github usernames separated by commas
+reviewers: username1,username2


### PR DESCRIPTION
Add a concourse pipeline that is triggered by new versions of
https://staging.openstax.org/rex/environment.json, regenerates the
`rex-uris.map` files based on what books are on the rex release, pushes
a branch in cnx-deploy called `update-rex-redirects-staging` and creates
a pull request for developers to review.

---

Remember to remove the :skull: commit before merging.