### PR TITLE
Change rex-redirects PRs to use assignees instead of reviewers

### DIFF
--- a/rex-redirects/create_pr.sh
+++ b/rex-redirects/create_pr.sh
@@ -12,5 +12,5 @@ tar xf "hub-linux-amd64-$HUB_VERSION.tgz" "hub-linux-amd64-$HUB_VERSION/bin/hub"
 # check whether PR already exists
 if [ -z "$("hub-linux-amd64-$HUB_VERSION/bin/hub" pr list -h "$CNX_DEPLOY_BRANCH")" ]
 then
-  "hub-linux-amd64-$HUB_VERSION/bin/hub" pull-request -f --no-edit -r "$REVIEWERS"
+  "hub-linux-amd64-$HUB_VERSION/bin/hub" pull-request -f --no-edit -a "$ASSIGNEES"
 fi

--- a/rex-redirects/pipeline.yml
+++ b/rex-redirects/pipeline.yml
@@ -98,4 +98,4 @@ jobs:
       HUB_VERSION: 2.12.3
       GITHUB_TOKEN: ((github-token))
       CNX_DEPLOY_BRANCH: ((cnx-deploy-branch))
-      REVIEWERS: ((reviewers))
+      ASSIGNEES: ((assignees))

--- a/rex-redirects/vars.yml.example
+++ b/rex-redirects/vars.yml.example
@@ -37,6 +37,5 @@ archive-host: archive-staging.cnx.org
 #   scope: public_repo
 github-token: ddce5dc0db5146eea35f88d63cb104f0
 
-# reviewers cannot include PR author
 # github usernames separated by commas
-reviewers: username1,username2
+assignees: username1,username2


### PR DESCRIPTION
Reviewers cannot include the author of the PR but really this is a
generated PR so we should include the author and all the other ce devs.

---

This isn't actually related to openstax/cnx#695 but anyway, a change to the rex redirects PR pipeline.