### PR TITLE
Add pipeline for releasing oer.exports

### DIFF
--- a/release-oer-exports/pipeline.yml
+++ b/release-oer-exports/pipeline.yml
@@ -1,0 +1,47 @@
+---
+
+resources:
+  - name: oer-exports
+    type: git
+    source:
+      uri: git@github.com:openstax/oer.exports.git
+      private_key: ((git-private-key))
+      tag_filter: '*'
+
+  - name: concourse-pipelines
+    type: git
+    source:
+      uri: https://github.com/openstax/concourse-pipelines.git
+
+jobs:
+  - name: release oer.exports
+    plan:
+      - get: oer-exports
+        trigger: true
+
+      - get: concourse-pipelines
+
+      - task: release-oer-exports
+        config:
+          platform: linux
+          image_resource:
+            type: docker-image
+            source:
+              repository: shimizukawa/python-all
+
+          inputs:
+            - name: oer-exports
+            - name: concourse-pipelines
+          outputs:
+            - name: rhaptos-print-updated
+          run:
+            path: concourse-pipelines/release-oer-exports/release-oer-exports.sh
+
+        params:
+          DIST_RHAPTOS_USERNAME: ((dist-rhaptos-username))
+          DIST_RHAPTOS_PASSWORD: ((dist-rhaptos-password))
+          DIST_RHAPTOS_URL: http://dist.rhaptos.org
+          RHAPTOS_PRINT_REPO_URL: git@github.com:Rhaptos/Products.RhaptosPrint.git
+          GIT_PRIVATE_KEY: ((git-private-key))
+          GIT_USER_EMAIL: ((git-user-email))
+          GIT_USER_NAME: ((git-user-name))

--- a/release-oer-exports/release-oer-exports.sh
+++ b/release-oer-exports/release-oer-exports.sh
@@ -1,0 +1,90 @@
+#!/bin/bash
+
+set -e
+
+# create .pypirc
+cat >$HOME/.pypirc <<EOF
+[distutils]
+index-servers =
+  dist-rhaptos
+
+[dist-rhaptos]
+repository = $DIST_RHAPTOS_URL
+username = $DIST_RHAPTOS_USERNAME
+password = $DIST_RHAPTOS_PASSWORD
+EOF
+
+# create ssh private keys
+mkdir $HOME/.ssh
+cat >$HOME/.ssh/id_rsa <<EOF
+$GIT_PRIVATE_KEY
+EOF
+chmod 600 $HOME/.ssh/id_rsa
+
+set +x
+
+# Install git
+apt-get update && apt-get install -y git
+git config --global user.email "$GIT_USER_EMAIL"
+git config --global user.name "$GIT_USER_NAME"
+
+# add github as known host
+ssh -o StrictHostKeyChecking=no -T git@github.com || echo 'Added github as known host'
+
+# Download and run ez_setup.py which installs setuptools
+python2.4 -c 'import urllib2; open("ez_setup.py", "w").write(urllib2.urlopen("https://raw.githubusercontent.com/pypa/setuptools/archive/bootstrap-py24/ez_setup.py").read())'
+python2.4 ez_setup.py
+rm -f ez_setup.py
+
+# Download and install pip
+python2.4 -c 'import urllib2; open("pip-1.1.tar.gz", "w").write(urllib2.urlopen("https://pypi.python.org/packages/source/p/pip/pip-1.1.tar.gz#md5=62a9f08dd5dc69d76734568a6c040508").read())'
+tar xf pip-1.1.tar.gz
+cd pip-1.1
+python2.4 setup.py install
+cd ..
+rm -rf pip-1.1
+
+# Install collective.dist 0.2.5
+pip install -i https://pypi.python.org/simple/ 'collective.dist==0.2.5' 'docutils==0.5'
+
+# Find the current tag of oer.exports
+cd oer-exports
+oer_exports_tag=$(git describe --exact-match --tags)
+
+# Clone Products.RhaptosPrint
+git clone $RHAPTOS_PRINT_REPO_URL Products.RhaptosPrint
+cd Products.RhaptosPrint
+
+# Initialize and update oer.exports (Products/Rhaptos/epub)
+git submodule init
+git submodule update
+
+# Merge Products.RhaptosPrint master into the production branch
+git checkout production
+git merge master
+
+# Merge oer.exports current tag into the production branch
+cd Products/RhaptosPrint/epub
+git checkout production
+git merge --no-edit tags/$oer_exports_tag
+git push origin HEAD
+
+# Update RhaptosPrint version and changelog
+cd .. # Products.RhaptosPrint/Products/RhaptosPrint/
+old_version=$(cat version.txt)
+new_version=$(awk -F. '{print $1 "." $2 + 1}' version.txt)
+echo $new_version >version.txt
+echo "RhaptosPrint-${new_version}" >CHANGES
+echo "  - $(cat epub/version.txt)" >>CHANGES
+git log --format='  - %s' $old_version.. >>CHANGES
+echo >>CHANGES
+cat CHANGES.txt >>CHANGES
+mv CHANGES CHANGES.txt
+git commit -m "version bump ${new_version}" -a
+git push origin HEAD
+git tag $new_version
+git push origin $new_version
+
+# Upload RhaptosPrint to dist server
+cd ../.. # Products.RhaptosPrint/
+python2.4 setup.py mregister sdist bdist_egg mupload -r dist-rhaptos


### PR DESCRIPTION
Following the instructions on the devops wiki page
https://github.com/openstax/devops/wiki/Setting-up-for-producing-eggs,
create a concourse pipeline that is triggered by oer.exports tags and
upload a new version of Products.RhaptosPrint to the dist server.