### PR TITLE
Bakery pipeline to generate neb config before neb get

### DIFF
--- a/bakery/tasks/t-fetch-book.yml
+++ b/bakery/tasks/t-fetch-book.yml
@@ -17,5 +17,12 @@ run:
     - -cxe
     - |
       exec 2> >(tee book/stderr >&2)
-      yes | neb get -r -d "./temp" "$(cat book-title/server | cut -f1 -d".")" "$(cat book-title/collection_id)" "$(cat book-title/version)"
+      mkdir -p ~/.config/
+      server="$(cat book-title/server)"
+      cat >~/.config/nebuchadnezzar.ini <<EOF
+      [settings]
+      [environ-$server]
+      url = https://$server
+      EOF
+      yes | neb get -r -d "./temp" "$(cat book-title/server)" "$(cat book-title/collection_id)" "$(cat book-title/version)"
       mv temp/* book


### PR DESCRIPTION
The default nebuchadnezzar.ini has a predefined list of servers
available, there's a possibility that the server that the user specifies
is not in that list.

So instead of using the default nebuchadnezzar.ini, generate one for the
server specified so `neb get` will always work.

---

Addresses openstax/cnx#772 and openstax/cnx#782