### PR TITLE
Bakery pipeline to output pdf filename with job id etc

### DIFF
--- a/bakery/pipeline.yml
+++ b/bakery/pipeline.yml
@@ -71,10 +71,12 @@ jobs:
               - |
                 exec 2> >(tee book/stderr >&2)
                 tail output-producer-queued/*
-                cp output-producer-queued/id book/event_id
+                cp output-producer-queued/id book/job_id
                 cp output-producer-queued/collection_id book/collection_id
                 cp output-producer-queued/version book/version
                 cp output-producer-queued/content_server book/server
+                wget -q -O jq 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64' && chmod +x jq
+                server_name="$(cat output-producer-queued/job.json | ./jq -r '.content_server.name')"
                 wget -q https://raw.githubusercontent.com/openstax/cnx-recipes/master/books.txt
                 set +x
                 . books.txt
@@ -88,7 +90,8 @@ jobs:
                     echo -n "$recipe_name" >book/recipe
                   fi
                 done
-                echo -n "https://ce-pdf-spike.s3.amazonaws.com/$(cat book/name).pdf" >book/pdf_url
+                echo -n "$(cat book/collection_id)-$(cat book/version)-${server_name}-$(cat book/job_id).pdf" >book/pdf_filename
+                echo -n "https://ce-pdf-spike.s3.amazonaws.com/$(cat book/pdf_filename)" >book/pdf_url
                 if [ ! -f book/name ]
                 then
                   set +x

--- a/bakery/tasks/build-pdf.yml
+++ b/bakery/tasks/build-pdf.yml
@@ -20,4 +20,4 @@ run:
       exec 2> >(tee artifacts/stderr >&2)
       rm -f mathified-book/stderr
       book_dir="mathified-book/$(cat book/name)"
-      prince -v --output="artifacts/$(cat book/name).pdf" "$book_dir/collection.mathified.xhtml"
+      prince -v --output="artifacts/$(cat book/pdf_filename)" "$book_dir/collection.mathified.xhtml"

--- a/bakery/tasks/t-book-lookup.yml
+++ b/bakery/tasks/t-book-lookup.yml
@@ -20,6 +20,9 @@ run:
       cp output-producer-queued/collection_id   book-title/collection_id
       cp output-producer-queued/version         book-title/version
       cp output-producer-queued/content_server  book-title/server
+      wget -q -O jq 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64' && chmod +x jq
+      server_name="$(cat output-producer-queued/job.json | ./jq -r '.content_server.name')"
+      echo -n "$(cat book-title/collection_id)-$(cat book-title/version)-${server_name}.pdf" >book-title/pdf_filename
       wget -q https://raw.githubusercontent.com/openstax/cnx-recipes/master/books.txt
       set +x
       . books.txt

--- a/bakery/tasks/t-build-pdf.yml
+++ b/bakery/tasks/t-build-pdf.yml
@@ -19,5 +19,5 @@ run:
     - |
       exec 2> >(tee s3/book/stderr >&2)
       rm -f artifacts/stderr
-      prince -v --output="artifacts/$(cat book-title/name).pdf" "s3/book/collection.assembled.xhtml"
-      echo -n "https://ce-pdf-spike.s3.amazonaws.com/artifacts/$(cat book-title/name).pdf" >artifacts/pdf_url
+      prince -v --output="artifacts/$(cat book-title/pdf_filename)" "s3/book/collection.assembled.xhtml"
+      echo -n "https://ce-pdf-spike.s3.amazonaws.com/artifacts/$(cat book-title/pdf_filename)" >artifacts/pdf_url


### PR DESCRIPTION
Output pdf filename should contain book collection id, version number,
server name and job id, e.g. `col12345-1.23-staging-5.pdf`.