### PR TITLE
update to use concourse repo for tasks

### DIFF
--- a/bakery/pipeline.yml
+++ b/bakery/pipeline.yml
@@ -6,10 +6,10 @@ resource_types:
       repository: openstax/output-producer-resource
 
 resources:
-  - name: pdf-spike
+  - name: opsx-pipelines
     type: git
     source:
-      uri: https://github.com/openstax/pdf-spike.git
+      uri: https://github.com/openstax/concourse-pipelines.git
 
   - name: cnx-recipes
     type: git
@@ -48,7 +48,7 @@ jobs:
           id: output-producer-queued/id
           status_id: "2" # Assigned
 
-      - get: pdf-spike
+      - get: opsx-pipelines
       - get: cnx-recipes
 
       - task: look up book
@@ -110,7 +110,7 @@ jobs:
             status_id: "4" # Failed
 
       - task: fetch book
-        file: pdf-spike/bakery/tasks/fetch-book.yml
+        file: opsx-pipelines/bakery/tasks/fetch-book.yml
         on_failure:
           put: output-producer-updater
           params:
@@ -118,7 +118,7 @@ jobs:
             status_id: "4" # Failed
 
       - task: assemble-book
-        file: pdf-spike/bakery/tasks/assemble-book.yml
+        file: opsx-pipelines/bakery/tasks/assemble-book.yml
         on_failure:
           put: output-producer-updater
           params:
@@ -126,7 +126,7 @@ jobs:
             status_id: "4" # Failed
 
       - task: bake-book
-        file: pdf-spike/bakery/tasks/bake-book.yml
+        file: opsx-pipelines/bakery/tasks/bake-book.yml
         on_failure:
           put: output-producer-updater
           params:
@@ -134,7 +134,7 @@ jobs:
             status_id: "4" # Failed
 
       - task: mathify-book
-        file: pdf-spike/bakery/tasks/mathify-book.yml
+        file: opsx-pipelines/bakery/tasks/mathify-book.yml
         on_failure:
           put: output-producer-updater
           params:
@@ -142,7 +142,7 @@ jobs:
             status_id: "4" # Failed
 
       - task: build-pdf
-        file: pdf-spike/bakery/tasks/build-pdf.yml
+        file: opsx-pipelines/bakery/tasks/build-pdf.yml
         on_failure:
           put: output-producer-updater
           params:


### PR DESCRIPTION
use the new repo for concourse pipeline, and not pdf-spike.