### PR TITLE
fix double .pdf.pdf files

### DIFF
--- a/bakery/README.md
+++ b/bakery/README.md
@@ -1,0 +1,13 @@
+# About
+
+This autogenerates a [./pipeline.yml](./pipeline.yml) file.
+
+# Install
+
+```sh
+# Install dependencies
+yarn
+
+# Generate pipeline.yml
+yarn build
+```

--- a/bakery/package.json
+++ b/bakery/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "node ./pipeline.js",
+    "build": "node ./pipeline.js > pipeline.yml",
     "lint": "standard ./pipeline.js ./tasks/*"
   },
   "dependencies": {

--- a/bakery/pipeline.yml
+++ b/bakery/pipeline.yml
@@ -259,7 +259,7 @@ jobs:
 
                 book_dir="mathified-book/$(cat book/name)"
 
-                prince -v --output="artifacts/$(cat book/pdf_filename).pdf"
+                prince -v --output="artifacts/$(cat book/pdf_filename)"
                 "$book_dir/collection.mathified.xhtml"
       - put: s3
         params:

--- a/bakery/tasks/build-pdf.js
+++ b/bakery/tasks/build-pdf.js
@@ -23,7 +23,7 @@ const task = {
         dedent`
           exec 2> >(tee artifacts/stderr >&2)
           book_dir="mathified-book/$(cat book/name)"
-          prince -v --output="artifacts/$(cat book/pdf_filename).pdf" "$book_dir/collection.mathified.xhtml"
+          prince -v --output="artifacts/$(cat book/pdf_filename)" "$book_dir/collection.mathified.xhtml"
         `
       ]
     }


### PR DESCRIPTION
The pipeline was generating `*.pdf.pdf` files but reporting `*.pdf` files.


[Slack Context](https://openstax.slack.com/archives/C0LA54Q5C/p1580340664318000?thread_ts=1580334316.304000&cid=C0LA54Q5C)