### PR TITLE
Tweaks for issues from recent deployment

### DIFF
--- a/bakery/README.md
+++ b/bakery/README.md
@@ -8,7 +8,7 @@
 ### Generate a pipeline file
 - Run `yarn build [path/to/output]`
   
-  Note: Directory for output path must exist. If no path argument is given, the pipeline will output to stdout.
+  Note: Directory for output path must exist. If no path argument is given, the pipeline will output to `pipeline.yml` in the current working directory.
 
 ### Development
 - There is no test suite in this repo, but a `yarn lint` command is provided to lint your work. This project uses `standard` to lint.

--- a/bakery/README.md
+++ b/bakery/README.md
@@ -1,0 +1,15 @@
+## Bakery Concourse Pipeline Generator
+
+### Setup
+- Install NodeJS and `yarn` on your machine.
+- Ensure `bakery/` is your working directory.
+- Run `yarn install` or `yarn`.
+
+### Generate a pipeline file
+- Run `yarn build [path/to/output]`
+  
+  Note: Directory for output path must exist. If no path argument is given, the pipeline will output to stdout.
+
+### Development
+- There is no test suite in this repo, but a `yarn lint` command is provided to lint your work. This project uses `standard` to lint.
+- Recommended way to verify your work is to go to the `output-producer-service` repository, start the `docker-compose` services in dev mode, and set-pipeline on the included concourse instance with a generated file by this repository.

--- a/bakery/credentials.yml.template
+++ b/bakery/credentials.yml.template
@@ -2,5 +2,3 @@ aws-sandbox-secret-key-id:
 aws-sandbox-secret-access-key:
 s3bucket:
 s3region:
-
-pdf-job-queue-url:

--- a/bakery/pipeline.js
+++ b/bakery/pipeline.js
@@ -95,7 +95,8 @@ const bakeryJob = {
     pdf_url: 'book/pdf_url'
   }),
   on_failure: reportToOutputProducer(Status.FAILED),
-  on_error: reportToOutputProducer(Status.FAILED),
+  // TODO: Uncomment this when upgrading to concourse >=5.0.1
+  // on_error: reportToOutputProducer(Status.FAILED),
   on_abort: reportToOutputProducer(Status.FAILED)
 }
 

--- a/bakery/pipeline.js
+++ b/bakery/pipeline.js
@@ -53,7 +53,7 @@ const resources = [
     name: 'output-producer',
     type: 'output-producer',
     source: {
-      api_root: '((pdf-job-queue-url))',
+      api_root: 'https://cops.cnx.org/api',
       status_id: 1
     }
   },

--- a/bakery/pipeline.js
+++ b/bakery/pipeline.js
@@ -121,5 +121,5 @@ const output = info + yaml.safeDump(config)
 if (outputFile) {
   fs.writeFileSync(outputFile, output)
 } else {
-  console.log(output)
+  fs.writeFileSync("pipeline.yml", output)
 }

--- a/bakery/pipeline.yml
+++ b/bakery/pipeline.yml
@@ -21,7 +21,7 @@ resources:
   - name: output-producer
     type: output-producer
     source:
-      api_root: ((pdf-job-queue-url))
+      api_root: 'https://cops.cnx.org/api'
       status_id: 1
   - name: s3
     type: s3
@@ -259,7 +259,7 @@ jobs:
 
                 book_dir="mathified-book/$(cat book/name)"
 
-                prince -v --output="artifacts/$(cat book/pdf_filename).pdf"
+                prince -v --output="artifacts/$(cat book/pdf_filename)"
                 "$book_dir/collection.mathified.xhtml"
       - put: s3
         params:
@@ -277,14 +277,8 @@ jobs:
       params:
         id: output-producer/id
         status_id: 4
-    on_error:
-      put: output-producer
-      params:
-        id: output-producer/id
-        status_id: 4
     on_abort:
       put: output-producer
       params:
         id: output-producer/id
         status_id: 4
-

--- a/bakery/tasks/build-pdf.js
+++ b/bakery/tasks/build-pdf.js
@@ -23,7 +23,7 @@ const task = {
         dedent`
           exec 2> >(tee artifacts/stderr >&2)
           book_dir="mathified-book/$(cat book/name)"
-          prince -v --output="artifacts/$(cat book/pdf_filename).pdf" "$book_dir/collection.mathified.xhtml"
+          prince -v --output="artifacts/$(cat book/pdf_filename)" "$book_dir/collection.mathified.xhtml"
         `
       ]
     }


### PR DESCRIPTION
- Added a basic README to the bakery directory
- Commented out code that is only compatible with newer versions of concourse
- Removed an extra '.pdf' that had slipped into the pdf naming code
- Remove the variable used for the api endpoint since the secrets manager did
  not handle that

I opened a container with concourse 4.2.2 and set-pipeline on it to enure the pipeline generated was indeed valid.