### PR TITLE
Remove dependency on recipes books.txt

### DIFF
--- a/bakery/env/local.json
+++ b/bakery/env/local.json
@@ -1,6 +1,6 @@
 {
   "ENV_NAME": "local",
-  "COPS_TARGET": "http:/backend/api",
+  "COPS_TARGET": "http://backend/api",
   "S3_BUCKET": "my-bucket",
   "S3_ACCESS_KEY_ID": "",
   "S3_SECRET_ACCESS_KEY": ""

--- a/bakery/pipeline.local.yml
+++ b/bakery/pipeline.local.yml
@@ -20,7 +20,7 @@ resources:
   - name: output-producer
     type: output-producer
     source:
-      api_root: 'http:/backend/api'
+      api_root: 'http://backend/api'
       status_id: 1
   - name: s3
     type: s3
@@ -49,7 +49,6 @@ jobs:
               repository: openstax/nebuchadnezzar
           inputs:
             - name: output-producer
-            - name: cnx-recipes
           outputs:
             - name: book
           run:
@@ -78,36 +77,12 @@ jobs:
                 server_name="$(cat output-producer/job.json | ./jq -r
                 '.content_server.name')"
 
-                set +x
-
-                . cnx-recipes/books.txt
-
-                set -x
-
-                for book_config in "${BOOK_CONFIGS[@]}"
-
-                do
-                  read -r book_name recipe_name _ book_colid _ <<< "$book_config"
-                  if [ "$book_colid" == "$(cat book/collection_id)" ]
-                  then
-                    echo -n "$book_name" >book/name
-                  fi
-                done
-
                 echo -n "$(cat book/collection_id)-$(cat
                 book/version)-${server_name}-$(cat book/job_id).pdf"
                 >book/pdf_filename
 
                 echo -n "https://my-bucket.s3.amazonaws.com/$(cat
                 book/pdf_filename)" >book/pdf_url
-
-                if [ ! -f book/name ]
-
-                then
-                  set +x
-                  echo "Book not found" >book/stderr
-                  exit 1
-                fi
       - put: output-producer
         params:
           id: output-producer/id
@@ -132,7 +107,7 @@ jobs:
 
                 cd fetched-book
 
-                book_dir="$(cat ../book/name)"
+                book_dir="$(cat ../book/collection_id)"
 
                 mkdir -p "$book_dir" ~/.config/
 
@@ -170,7 +145,7 @@ jobs:
                 exec 2> >(tee assembled-book/stderr >&2)
                 cp -r fetched-book/* assembled-book
                 cd assembled-book
-                book_dir="../assembled-book/$(cat ../book/name)"
+                book_dir="../assembled-book/$(cat ../book/collection_id)"
                 neb assemble "$book_dir/raw" "$book_dir"
       - task: bake book
         config:
@@ -194,7 +169,7 @@ jobs:
 
                 cp -r assembled-book/* baked-book
 
-                book_dir="baked-book/$(cat book/name)"
+                book_dir="baked-book/$(cat book/collection_id)"
 
                 cnx-easybake -q "cnx-recipes/recipes/output/$(cat
                 book/style).css" "$book_dir/collection.assembled.xhtml"
@@ -231,7 +206,7 @@ jobs:
 
                 cp -r baked-book/* mathified-book
 
-                book_dir=mathified-book/$(cat book/name)
+                book_dir=mathified-book/$(cat book/collection_id)
 
                 node /src/typeset/start -i "$book_dir/collection.baked.xhtml" -o
                 "$book_dir/collection.mathified.xhtml" -f svg
@@ -255,7 +230,7 @@ jobs:
               - >-
                 exec 2> >(tee artifacts/stderr >&2)
 
-                book_dir="mathified-book/$(cat book/name)"
+                book_dir="mathified-book/$(cat book/collection_id)"
 
                 prince -v --output="artifacts/$(cat book/pdf_filename)"
                 "$book_dir/collection.mathified.xhtml"

--- a/bakery/pipeline.staging.yml
+++ b/bakery/pipeline.staging.yml
@@ -49,7 +49,6 @@ jobs:
               repository: openstax/nebuchadnezzar
           inputs:
             - name: output-producer
-            - name: cnx-recipes
           outputs:
             - name: book
           run:
@@ -78,36 +77,12 @@ jobs:
                 server_name="$(cat output-producer/job.json | ./jq -r
                 '.content_server.name')"
 
-                set +x
-
-                . cnx-recipes/books.txt
-
-                set -x
-
-                for book_config in "${BOOK_CONFIGS[@]}"
-
-                do
-                  read -r book_name recipe_name _ book_colid _ <<< "$book_config"
-                  if [ "$book_colid" == "$(cat book/collection_id)" ]
-                  then
-                    echo -n "$book_name" >book/name
-                  fi
-                done
-
                 echo -n "$(cat book/collection_id)-$(cat
                 book/version)-${server_name}-$(cat book/job_id).pdf"
                 >book/pdf_filename
 
                 echo -n "https://ce-cops-staging.s3.amazonaws.com/$(cat
                 book/pdf_filename)" >book/pdf_url
-
-                if [ ! -f book/name ]
-
-                then
-                  set +x
-                  echo "Book not found" >book/stderr
-                  exit 1
-                fi
       - put: output-producer
         params:
           id: output-producer/id
@@ -132,7 +107,7 @@ jobs:
 
                 cd fetched-book
 
-                book_dir="$(cat ../book/name)"
+                book_dir="$(cat ../book/collection_id)"
 
                 mkdir -p "$book_dir" ~/.config/
 
@@ -170,7 +145,7 @@ jobs:
                 exec 2> >(tee assembled-book/stderr >&2)
                 cp -r fetched-book/* assembled-book
                 cd assembled-book
-                book_dir="../assembled-book/$(cat ../book/name)"
+                book_dir="../assembled-book/$(cat ../book/collection_id)"
                 neb assemble "$book_dir/raw" "$book_dir"
       - task: bake book
         config:
@@ -194,7 +169,7 @@ jobs:
 
                 cp -r assembled-book/* baked-book
 
-                book_dir="baked-book/$(cat book/name)"
+                book_dir="baked-book/$(cat book/collection_id)"
 
                 cnx-easybake -q "cnx-recipes/recipes/output/$(cat
                 book/style).css" "$book_dir/collection.assembled.xhtml"
@@ -231,7 +206,7 @@ jobs:
 
                 cp -r baked-book/* mathified-book
 
-                book_dir=mathified-book/$(cat book/name)
+                book_dir=mathified-book/$(cat book/collection_id)
 
                 node /src/typeset/start -i "$book_dir/collection.baked.xhtml" -o
                 "$book_dir/collection.mathified.xhtml" -f svg
@@ -255,7 +230,7 @@ jobs:
               - >-
                 exec 2> >(tee artifacts/stderr >&2)
 
-                book_dir="mathified-book/$(cat book/name)"
+                book_dir="mathified-book/$(cat book/collection_id)"
 
                 prince -v --output="artifacts/$(cat book/pdf_filename)"
                 "$book_dir/collection.mathified.xhtml"

--- a/bakery/pipeline.yml
+++ b/bakery/pipeline.yml
@@ -49,7 +49,6 @@ jobs:
               repository: openstax/nebuchadnezzar
           inputs:
             - name: output-producer
-            - name: cnx-recipes
           outputs:
             - name: book
           run:
@@ -78,36 +77,12 @@ jobs:
                 server_name="$(cat output-producer/job.json | ./jq -r
                 '.content_server.name')"
 
-                set +x
-
-                . cnx-recipes/books.txt
-
-                set -x
-
-                for book_config in "${BOOK_CONFIGS[@]}"
-
-                do
-                  read -r book_name recipe_name _ book_colid _ <<< "$book_config"
-                  if [ "$book_colid" == "$(cat book/collection_id)" ]
-                  then
-                    echo -n "$book_name" >book/name
-                  fi
-                done
-
                 echo -n "$(cat book/collection_id)-$(cat
                 book/version)-${server_name}-$(cat book/job_id).pdf"
                 >book/pdf_filename
 
                 echo -n "https://ce-pdf-spike.s3.amazonaws.com/$(cat
                 book/pdf_filename)" >book/pdf_url
-
-                if [ ! -f book/name ]
-
-                then
-                  set +x
-                  echo "Book not found" >book/stderr
-                  exit 1
-                fi
       - put: output-producer
         params:
           id: output-producer/id
@@ -132,7 +107,7 @@ jobs:
 
                 cd fetched-book
 
-                book_dir="$(cat ../book/name)"
+                book_dir="$(cat ../book/collection_id)"
 
                 mkdir -p "$book_dir" ~/.config/
 
@@ -170,7 +145,7 @@ jobs:
                 exec 2> >(tee assembled-book/stderr >&2)
                 cp -r fetched-book/* assembled-book
                 cd assembled-book
-                book_dir="../assembled-book/$(cat ../book/name)"
+                book_dir="../assembled-book/$(cat ../book/collection_id)"
                 neb assemble "$book_dir/raw" "$book_dir"
       - task: bake book
         config:
@@ -194,7 +169,7 @@ jobs:
 
                 cp -r assembled-book/* baked-book
 
-                book_dir="baked-book/$(cat book/name)"
+                book_dir="baked-book/$(cat book/collection_id)"
 
                 cnx-easybake -q "cnx-recipes/recipes/output/$(cat
                 book/style).css" "$book_dir/collection.assembled.xhtml"
@@ -231,7 +206,7 @@ jobs:
 
                 cp -r baked-book/* mathified-book
 
-                book_dir=mathified-book/$(cat book/name)
+                book_dir=mathified-book/$(cat book/collection_id)
 
                 node /src/typeset/start -i "$book_dir/collection.baked.xhtml" -o
                 "$book_dir/collection.mathified.xhtml" -f svg
@@ -255,7 +230,7 @@ jobs:
               - >-
                 exec 2> >(tee artifacts/stderr >&2)
 
-                book_dir="mathified-book/$(cat book/name)"
+                book_dir="mathified-book/$(cat book/collection_id)"
 
                 prince -v --output="artifacts/$(cat book/pdf_filename)"
                 "$book_dir/collection.mathified.xhtml"

--- a/bakery/src/tasks/assemble-book.js
+++ b/bakery/src/tasks/assemble-book.js
@@ -24,7 +24,7 @@ const task = () => {
           exec 2> >(tee assembled-book/stderr >&2)
           cp -r fetched-book/* assembled-book
           cd assembled-book
-          book_dir="../assembled-book/$(cat ../book/name)"
+          book_dir="../assembled-book/$(cat ../book/collection_id)"
           neb assemble "$book_dir/raw" "$book_dir"
         `
         ]

--- a/bakery/src/tasks/bake-book.js
+++ b/bakery/src/tasks/bake-book.js
@@ -24,7 +24,7 @@ const task = () => {
           dedent`
           exec 2> >(tee baked-book/stderr >&2)
           cp -r assembled-book/* baked-book
-          book_dir="baked-book/$(cat book/name)"
+          book_dir="baked-book/$(cat book/collection_id)"
           cnx-easybake -q "cnx-recipes/recipes/output/$(cat book/style).css" "$book_dir/collection.assembled.xhtml" "$book_dir/collection.baked.xhtml"
           style_file="cnx-recipes/styles/output/$(cat book/style)-pdf.css"
           if [ -f "$style_file" ]

--- a/bakery/src/tasks/build-pdf.js
+++ b/bakery/src/tasks/build-pdf.js
@@ -23,7 +23,7 @@ const task = () => {
           '-cxe',
           dedent`
           exec 2> >(tee artifacts/stderr >&2)
-          book_dir="mathified-book/$(cat book/name)"
+          book_dir="mathified-book/$(cat book/collection_id)"
           prince -v --output="artifacts/$(cat book/pdf_filename)" "$book_dir/collection.mathified.xhtml"
         `
         ]

--- a/bakery/src/tasks/fetch-book.js
+++ b/bakery/src/tasks/fetch-book.js
@@ -20,7 +20,7 @@ const task = () => {
           dedent`
           exec 2> >(tee fetched-book/stderr >&2)
           cd fetched-book
-          book_dir="$(cat ../book/name)"
+          book_dir="$(cat ../book/collection_id)"
           mkdir -p "$book_dir" ~/.config/
           server="$(cat ../book/server)"
           cat >~/.config/nebuchadnezzar.ini <<EOF

--- a/bakery/src/tasks/look-up-book.js
+++ b/bakery/src/tasks/look-up-book.js
@@ -11,7 +11,7 @@ const task = ({ bucketName }) => {
           repository: 'openstax/nebuchadnezzar'
         }
       },
-      inputs: [{ name: 'output-producer' }, { name: 'cnx-recipes' }],
+      inputs: [{ name: 'output-producer' }],
       outputs: [{ name: 'book' }],
       run: {
         path: '/bin/bash',
@@ -28,25 +28,8 @@ const task = ({ bucketName }) => {
           cp output-producer/content_server book/server
           wget -q -O jq 'https://github.com/stedolan/jq/releases/download/jq-1.6/jq-linux64' && chmod +x jq
           server_name="$(cat output-producer/job.json | ./jq -r '.content_server.name')"
-          set +x
-          . cnx-recipes/books.txt
-          set -x
-          for book_config in "${'${BOOK_CONFIGS[@]}'}"
-          do
-            read -r book_name recipe_name _ book_colid _ <<< "$book_config"
-            if [ "$book_colid" == "$(cat book/collection_id)" ]
-            then
-              echo -n "$book_name" >book/name
-            fi
-          done
           echo -n "$(cat book/collection_id)-$(cat book/version)-${'${server_name}'}-$(cat book/job_id).pdf" >book/pdf_filename
           echo -n "https://${bucketName}.s3.amazonaws.com/$(cat book/pdf_filename)" >book/pdf_url
-          if [ ! -f book/name ]
-          then
-            set +x
-            echo "Book not found" >book/stderr
-            exit 1
-          fi
         `
         /* eslint-enable */
         ]

--- a/bakery/src/tasks/mathify-book.js
+++ b/bakery/src/tasks/mathify-book.js
@@ -23,7 +23,7 @@ const task = () => {
           dedent`
           exec 2> >(tee mathified-book/stderr >&2)
           cp -r baked-book/* mathified-book
-          book_dir=mathified-book/$(cat book/name)
+          book_dir=mathified-book/$(cat book/collection_id)
           node /src/typeset/start -i "$book_dir/collection.baked.xhtml" -o "$book_dir/collection.mathified.xhtml" -f svg  
         `
         ]


### PR DESCRIPTION
The last thing we relied on books.txt for, the book title, never actually escaped the pipeline in any way. It was only used for the directory names for intermediate states. I've changed it to use the col_id instead and then removed the books.txt dependency.