### PR TITLE
Update rex-redirects pipeline inputs

### DIFF
--- a/rex-redirects/pipeline.yml
+++ b/rex-redirects/pipeline.yml
@@ -35,6 +35,11 @@ resources:
   source:
     uri: https://github.com/openstax/concourse-pipelines.git
 
+- name: cnx-rex-redirects
+  type: git
+  source:
+    uri: https://github.com/openstax/cnx-rex-redirects.git
+
 jobs:
 - name: job-update-rex-redirects
   plan:
@@ -42,6 +47,7 @@ jobs:
     trigger: true
   - get: cnx-deploy
   - get: concourse-pipelines
+  - get: cnx-rex-redirects
 
   - task: update-uri-maps
     config:
@@ -54,6 +60,7 @@ jobs:
       inputs:
       - name: cnx-deploy
       - name: concourse-pipelines
+      - name: cnx-rex-redirects
       outputs:
       - name: cnx-deploy-updated
       run:
@@ -63,7 +70,7 @@ jobs:
         - |
           cp -r cnx-deploy cnx-deploy-updated && \
           cd cnx-deploy-updated/cnx-deploy && \
-          ../../concourse-pipelines/rex-redirects/update_uri_map.sh
+          ../../concourse-pipelines/rex-redirects/update_uri_map.sh ../../cnx-rex-redirects
     params:
       OPENSTAX_HOST: openstax.org
       ARCHIVE_HOST: archive.cnx.org

--- a/rex-redirects/update_uri_map.sh
+++ b/rex-redirects/update_uri_map.sh
@@ -5,7 +5,8 @@ set -xe
 git checkout -b "$CNX_DEPLOY_BRANCH"
 
 # TODO install pypi version (not currently available)
-pip install git+https://github.com/openstax/cnx-rex-redirects.git
+# For now we expect to be passed the source directory for cnx-rex-redirects
+pip install $1
 
 git config --global user.email "$GIT_AUTHOR_EMAIL"
 git config --global user.name "$GIT_AUTHOR_NAME"


### PR DESCRIPTION
Currently updates to cnx-rex-redirects do not impact our pipeline
because it is not a defined input and hence even manual triggering
can't be used. This chagne incorporates the repo as a source input,
and later can be updated as a pypi resource once we have the package
available there.