### PR TITLE
type: docker-image -> type: registry-image

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ resources:
       tag_filter: '*'
 
   - name: docker-hub-image
-    type: docker-image
+    type: registry-image
     source:
       repository: docker-registry:5000/my-stuff  # We are pointing to the docker registry in docker-compose
       insecure_registries: ["docker-registry:5000"]  # Important that we specify that the registry is insecure
@@ -116,7 +116,7 @@ resources:
       tag_filter: '*'
 
   - name: docker-hub-image
-    type: docker-image
+    type: registry-image
     source:
       repository: docker-registry:5000/my-stuff  # Change this line to point to remote registry. Probably openstax/my-stuff (with no explicit host).
       insecure_registries: ["docker-registry:5000"]  # Remove this line

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ resources:
       tag_filter: '*'
 
   - name: docker-hub-image
-    type: registry-image
+    type: docker-image
     source:
       repository: docker-registry:5000/my-stuff  # We are pointing to the docker registry in docker-compose
       insecure_registries: ["docker-registry:5000"]  # Important that we specify that the registry is insecure
@@ -116,7 +116,7 @@ resources:
       tag_filter: '*'
 
   - name: docker-hub-image
-    type: registry-image
+    type: docker-image
     source:
       repository: docker-registry:5000/my-stuff  # Change this line to point to remote registry. Probably openstax/my-stuff (with no explicit host).
       insecure_registries: ["docker-registry:5000"]  # Remove this line

--- a/concourse-resources/pipeline.yml
+++ b/concourse-resources/pipeline.yml
@@ -12,7 +12,7 @@ resources:
       tag_filter: '*'
 
   - name: docker-hub-image
-    type: docker-image
+    type: registry-image
     source:
       repository: openstax/((github-repo))
       username: ((docker-hub-username))
@@ -28,7 +28,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source: {repository: busybox}
           outputs: [{name: 'tag-file'}]
           run:
@@ -53,7 +53,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source: {repository: alpine/git}
           inputs: [{name: 'source-code-tagged'}]
           outputs: [{name: 'tag-files'}]

--- a/image-autotag/pipeline.yml
+++ b/image-autotag/pipeline.yml
@@ -146,7 +146,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: alpine/git
               <<: *docker-credentials

--- a/release-oer-exports/pipeline.yml
+++ b/release-oer-exports/pipeline.yml
@@ -25,7 +25,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: shimizukawa/python-all
               username: ((ce-dockerhub-id))

--- a/rex-redirects/pipeline.yml
+++ b/rex-redirects/pipeline.yml
@@ -5,7 +5,7 @@ docker-credentials: &docker-credentials
 
 resource_types:
 - name: curl
-  type: docker-image
+  type: registry-image
   source:
     repository: pivotalservices/concourse-curl-resource
     tag: latest
@@ -59,7 +59,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           repository: python
           tag: 3.7-buster
@@ -92,7 +92,7 @@ jobs:
     config:
       platform: linux
       image_resource:
-        type: docker-image
+        type: registry-image
         source:
           repository: python
           tag: 3.7-buster

--- a/tag-cnx-deploy/pipeline.yml
+++ b/tag-cnx-deploy/pipeline.yml
@@ -27,7 +27,7 @@ jobs:
         config:
           platform: linux
           image_resource:
-            type: docker-image
+            type: registry-image
             source:
               repository: python
               tag: 3.8-slim


### PR DESCRIPTION
registry-image is a newer (almost) drop-in replacement for docker-image