### PR TITLE
Modified POET publish task to release to vscode extension marketplace

### DIFF
--- a/release-poet/pipeline.yml
+++ b/release-poet/pipeline.yml
@@ -70,6 +70,7 @@ jobs:
             - name: package-json
           params:
             OPENVSX_TOKEN: ((POET-openvsx-token))
+            VSCE_TOKEN: ((POET-vsce-token))
           run:
             path: /bin/bash
             args:
@@ -81,3 +82,4 @@ jobs:
                 npm run build:production
                 npm install ovsx
                 npx ovsx publish editor-*.vsix -p $OPENVSX_TOKEN
+                npx vsce login $(node -p "require('./package.json').publisher") <<< $VSCE_TOKEN && npx vsce publish --no-git-tag-version

--- a/release-poet/pipeline.yml
+++ b/release-poet/pipeline.yml
@@ -64,6 +64,7 @@ jobs:
             type: registry-image
             source:
               repository: node
+              tag: lts
               <<: *docker-credentials
           inputs:
             - name: source-code
@@ -82,4 +83,5 @@ jobs:
                 npm run build:production
                 npm install ovsx
                 npx ovsx publish editor-*.vsix -p $OPENVSX_TOKEN
-                npx vsce login $(node -p "require('./package.json').publisher") <<< $VSCE_TOKEN && npx vsce publish --no-git-tag-version
+                read version publisher <<< $(node -p "const pkg = require('./package.json'); [pkg.version, pkg.publisher].join(' ')")
+                npx vsce login $publisher <<< $VSCE_TOKEN && npx vsce publish $version


### PR DESCRIPTION
### Added steps to the publish task so that POET will be released on the official vscode marketplace in addition to open vsx.

For more information about vsce, see [vsce's main.ts](https://github.com/microsoft/vscode-vsce/blob/main/src/main.ts) (they do not really have documentation).

Steps added:
- Log into publisher listed in package.json
- publish extension